### PR TITLE
Update RestSharp dependency and fix compatibility

### DIFF
--- a/src/mParticle.Sdk.Test/mParticle.Sdk.Test.csproj
+++ b/src/mParticle.Sdk.Test/mParticle.Sdk.Test.csproj
@@ -3,14 +3,16 @@
   <PropertyGroup>
     <AssemblyName>mParticle.Test</AssemblyName>
     <RootNamespace>mParticle.Test</RootNamespace>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+<PrivateAssets>all</PrivateAssets>
+</PackageReference>
     <ProjectReference Include="..\mParticle.Sdk\mParticle.Sdk.csproj" />
   </ItemGroup>
 

--- a/src/mParticle.Sdk/Client/ApiClient.cs
+++ b/src/mParticle.Sdk/Client/ApiClient.cs
@@ -241,11 +241,17 @@ namespace mParticle.Client
             var existingDeserializer = req.JsonSerializer as IDeserializer;
             if (existingDeserializer != null)
             {
-                client.AddHandler(() => existingDeserializer, "application/json", "text/json", "text/x-json", "text/javascript", "*+json");
+                foreach (var type in new String[] { "application/json", "text/json", "text/x-json", "text/javascript", "*+json" })
+                {
+                    client.AddHandler(type, () => existingDeserializer);
+                }
             }
             else
             {
-                client.AddHandler(() => new CustomJsonCodec(configuration), "application/json", "text/json", "text/x-json", "text/javascript", "*+json");
+                foreach (var type in new String[] { "application/json", "text/json", "text/x-json", "text/javascript", "*+json" })
+                {
+                    client.AddHandler(type, () => new CustomJsonCodec(configuration));
+                }
             }
 
             client.Timeout = configuration.Timeout;
@@ -310,11 +316,15 @@ namespace mParticle.Client
             var existingDeserializer = req.JsonSerializer as IDeserializer;
             if (existingDeserializer != null)
             {
-                client.AddHandler(() => existingDeserializer, "application/json", "text/json", "text/x-json", "text/javascript", "*+json");
+                foreach (var type in new String[] { "application/json", "text/json", "text/x-json", "text/javascript", "*+json" })
+                {
+                    client.AddHandler(type, () => existingDeserializer);
+                }
             }
             else
             {
-                client.AddHandler(() => new CustomJsonCodec(configuration), "application/json", "text/json", "text/x-json", "text/javascript", "*+json");
+                foreach (var type in new String[] { "application/json", "text/json", "text/x-json", "text/javascript", "*+json" })
+                client.AddHandler(type, () => new CustomJsonCodec(configuration));
             }
 
             client.Timeout = configuration.Timeout;

--- a/src/mParticle.Sdk/mParticle.Sdk.csproj
+++ b/src/mParticle.Sdk/mParticle.Sdk.csproj
@@ -19,10 +19,10 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JsonSubTypes" Version="1.5.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="RestSharp" Version="106.10.1" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="JsonSubTypes" Version="1.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RestSharp" Version="106.11.7" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>mParticle.Test</_Parameter1>
     </AssemblyAttribute>


### PR DESCRIPTION
## Summary
The RestSharp library we depend on experience an update that broke its API since v106.10.1. This will update the dependency to its latest version, 106.11.7, and updated our usage

## Testing Plan
existing tests passed. I Observed the breaking change in a smoke test before making the fix, confirmed in smoke test that changes jettisoned the problem

## Master Issue
Closes https://go.mparticle.com/work/56909
