### PR TITLE
Implement MParticle.UploadAsync

### DIFF
--- a/src/mParticle.Sdk/Api/MParticle.cs
+++ b/src/mParticle.Sdk/Api/MParticle.cs
@@ -23,6 +23,11 @@ namespace mParticle.Api
         /// </summary>
         void Upload();
 
+        /// <summary>
+        /// Forces the upload of all events in the queue asynchronously
+        /// </summary>
+        Task UploadAsync();
+
          /// <summary>
         /// Get or Set the BaseBatch instance which will be used for uploading enqueued events
         /// logged via EventsApi#LogEvent
@@ -196,6 +201,14 @@ namespace mParticle.Api
         public void Upload()
         {
             _uploadQueue.ForceUpload();
+        }
+
+        /// <summary>
+        /// Forces the upload of all events in the queue asynchronously
+        /// </summary>
+        public async Task UploadAsync()
+        {
+            await _uploadQueue.ForceUploadAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
This "fixes" our `MParticle#Upload()` method. Previously we had it implemented it would run synchronously through the Batch creation logic, but then run the actual network upload asynchronously. This is pretty similar to how it works in the Android SDK, but the design doesn't work as well for the Dotnet SDK for a couple of reasons

1) there is no persistence in the Dotnet SDK, so, if on the native SDKs, the network upload doesn't complete by a certain point, it's no big deal since the messages are still there. If the network upload doesn't complete on the Dotnet SDK, the messages are gone
2) the Dotnet SDK and s2s sdks in general are designed to give more control over uploads to the client. In this case, we added message queueing for convenience, but the force upload function should be in line with the other upload methods, which is non-black-box

The issue was caused by the fact that the UploadQueue#Upload() is an async method which we were not calling with `await`. 

For the sake of consistency, I made the `MParticle#Upload()` method truly synchronous, by forcing it to wait for the result of the Batch Upload request, and I added a method `MParticle#UploadAsync()` which is an `async` method, that does the same thing by gives control over the execution to the client

## Testing Plan
Part of the reason this issue was never picked up is that we implemented the `ApiClient#UploadBatchAsync()` method in `UploadQueueTest` as "non-async" (no `async` keyword). I fixed this and the tests we wrote started failing since they implicitly rely on `Upload()` being synchronous. I updated those tests to use the fixed synchronous version of `Upload()` and added two more tests:
1) using `UploadAsync()` with `await`, check that the batch got sent out
2) using `UploadAsync()` without `await`, check that the batch did not get sent out (yet, it should still be inflight since the request was made async and hasn't returned by the time the test finishes)

## Master Issue
Closes https://go.mparticle.com/work/54082
