### PR TITLE
Handle 429 status code rate limiting for the logEvent/UploadQueue code path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   # SDK release is done from public master branch.
   confirm-master-branch:
     name: "Confirm release is run on master branch"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
@@ -25,14 +25,10 @@ jobs:
   build-test:
     name: "Build and Test"
     needs: confirm-master-branch
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
         uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.1.*
       - name: "Install dependencies"
         run: dotnet restore
       - name: "Build"
@@ -42,16 +38,12 @@ jobs:
   build-artifact:
     name: "Build Artifact and Release"
     needs: build-test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Git checkout"
         uses: actions/checkout@v2
         with:
           ref: master
-      - name: "Setup .NET Core"
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.1.*
       - name: "Setup Nuget"
         uses: nuget/setup-nuget@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: .NET Core
+name: Test
 
 on:
   push:
@@ -10,10 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 2.1.*
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/src/mParticle.Sdk.Test/Client/UploadQueueTest.cs
+++ b/src/mParticle.Sdk.Test/Client/UploadQueueTest.cs
@@ -17,7 +17,7 @@ namespace mParticle.Client
     {
 
         [Fact]
-        public void testBatchEventMaxLimit()
+        public void TestBatchEventMaxLimit()
         {
             var mParticle = new MockMParticle(new Configuration("apikey", "apiSecret"));
             var eventQueue = new UploadQueue((IMParticle)mParticle);
@@ -27,8 +27,8 @@ namespace mParticle.Client
                 eventQueue.AddEvent(e);
             }
             eventQueue.ForceUpload(false);
-            Assert.Single(mParticle.uploadedBatches);
-            Assert.Equal(100, mParticle.uploadedBatches[0].Events.Count);
+            Assert.Single(mParticle._uploadedBatches);
+            Assert.Equal(100, mParticle._uploadedBatches[0].Events.Count);
 
             List<object> a = new List<object>();
             a.Add(1);
@@ -45,9 +45,9 @@ namespace mParticle.Client
                 eventQueue.AddEvent(e);
             }
             eventQueue.ForceUpload(false);
-            Assert.Single(mParticle.uploadedBatches);
-            Assert.Equal(100, mParticle.uploadedBatches[0].Events.Count);
-            foreach (BaseEvent e in mParticle.uploadedBatches[0].Events)
+            Assert.Single(mParticle._uploadedBatches);
+            Assert.Equal(100, mParticle._uploadedBatches[0].Events.Count);
+            foreach (BaseEvent e in mParticle._uploadedBatches[0].Events)
             {
                 var eventNameNum = Int32.Parse(((CustomEvent)e).EventName);
                 Assert.True(eventNameNum <= 100 && eventNameNum > 0);
@@ -63,10 +63,10 @@ namespace mParticle.Client
             eventQueue.AddEvent(new CustomEvent("0"));
        
             await eventQueue.ForceUploadAsync(false);
-            Assert.Single(mParticle.uploadedBatches);
-            Assert.Single(mParticle.uploadedBatches[0].Events);
+            Assert.Single(mParticle._uploadedBatches);
+            Assert.Single(mParticle._uploadedBatches[0].Events);
             
-            var e = mParticle.uploadedBatches[0].Events[0];
+            var e = mParticle._uploadedBatches[0].Events[0];
             Assert.Equal("0", ((CustomEvent)e).EventName);
            
         }
@@ -82,17 +82,96 @@ namespace mParticle.Client
             eventQueue.ForceUploadAsync(false);
 
             //since we did not await, the network request should not have complete yet
-            Assert.Empty(mParticle.uploadedBatches);
+            Assert.Empty(mParticle._uploadedBatches);
+        }
+
+        [Fact]
+        public async void TestRateLimiting()
+        {
+            var headers = new Multimap<string, string>();
+            headers.Add("Retry-After", "600");
+            var mParticle = new MockMParticle(new Configuration("apikey", "apiSecret"), HttpStatusCode.TooManyRequests, headers);
+            var eventQueue = new UploadQueue((IMParticle)mParticle);
+
+            Assert.Empty(eventQueue._events);
+
+            eventQueue.AddEvent(new CustomEvent("0"));
+
+            // Confirm the event is in the queue
+            Assert.Single(eventQueue._events);
+            // Confirm the retry timestamp is before now
+            Assert.True(eventQueue._retryAfterTimestamp < DateTime.Now);
+
+            await eventQueue.ForceUploadAsync(false);
+
+            // Confirm the event is still in the queue
+            Assert.Single(eventQueue._events);
+            // Confirm that the retry timestamp was set to the content of Retry-After header
+            Assert.True(eventQueue._retryAfterTimestamp > DateTime.Now);
+        }
+
+        [Fact]
+        public async void TestRateLimitingMissingHeader()
+        {
+            var mParticle = new MockMParticle(new Configuration("apikey", "apiSecret"), HttpStatusCode.TooManyRequests);
+            var eventQueue = new UploadQueue((IMParticle)mParticle);
+
+            Assert.Empty(eventQueue._events);
+
+            eventQueue.AddEvent(new CustomEvent("0"));
+
+            // Confirm the event is in the queue
+            Assert.Single(eventQueue._events);
+            // Confirm the retry timestamp is before now
+            var retryAfterTimestamp = eventQueue._retryAfterTimestamp;
+            Assert.True(retryAfterTimestamp < DateTime.Now);
+
+            await eventQueue.ForceUploadAsync(false);
+
+            // Confirm the event is still in the queue
+            Assert.Single(eventQueue._events);
+            // Confirm that the retry timestamp was not changed
+            Assert.Equal(eventQueue._retryAfterTimestamp, retryAfterTimestamp);
+        }
+
+        [Fact]
+        public async void TestRateLimitingBadHeaderValue()
+        {
+            var headers = new Multimap<string, string>();
+            headers.Add("Retry-After", "sdkfjsdklf");
+            var mParticle = new MockMParticle(new Configuration("apikey", "apiSecret"), HttpStatusCode.TooManyRequests, headers);
+            var eventQueue = new UploadQueue((IMParticle)mParticle);
+
+            Assert.Empty(eventQueue._events);
+
+            eventQueue.AddEvent(new CustomEvent("0"));
+
+            // Confirm the event is in the queue
+            Assert.Single(eventQueue._events);
+            // Confirm the retry timestamp is before now
+            var retryAfterTimestamp = eventQueue._retryAfterTimestamp;
+            Assert.True(retryAfterTimestamp < DateTime.Now);
+
+            await eventQueue.ForceUploadAsync(false);
+
+            // Confirm the event is still in the queue
+            Assert.Single(eventQueue._events);
+            // Confirm that the retry timestamp was not changed
+            Assert.Equal(eventQueue._retryAfterTimestamp, retryAfterTimestamp);
         }
     }
-
+    
     internal class MockMParticle : IMParticle
     {
-
-        internal MockMParticle(Configuration configuration) {
+        internal MockMParticle(Configuration configuration, HttpStatusCode statusCode = HttpStatusCode.Accepted, Multimap<string, string> headers = null)
+        {
             Configuration = configuration;
+            _statusCode = statusCode;
+            _headers = headers == null ? new Multimap<string, string>() : headers;
         }
-        internal List<Batch> uploadedBatches = new List<Batch>();
+        internal List<Batch> _uploadedBatches = new List<Batch>();
+        internal HttpStatusCode _statusCode;
+        internal Multimap<string, string> _headers;
 
         public BaseBatch BaseBatch { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
@@ -102,32 +181,31 @@ namespace mParticle.Client
         {
             foreach (Batch batch in batches)
             {
-                uploadedBatches.Add(batch);
+                _uploadedBatches.Add(batch);
             }
-            return new ApiResponse<object>(HttpStatusCode.Accepted, new object(), "");
+            return new ApiResponse<object>(_statusCode, _headers, new object(), "");
         }
 
         Task<ApiResponse<object>> BulkUploadBatchesAsync(Collection<Batch> batches)
         {
             foreach (Batch batch in batches)
             {
-                uploadedBatches.Add(batch);
+                _uploadedBatches.Add(batch);
             }
-            return Task.Run(() => new ApiResponse<object>(HttpStatusCode.Accepted, new object(), ""));
+            return Task.Run(() => new ApiResponse<object>(_statusCode, _headers, new object(), ""));
         }
-
 
         public ApiResponse<object> UploadBatch(Batch batch)
         {
-            uploadedBatches.Add(batch);
-            return new ApiResponse<object>(HttpStatusCode.Accepted, new object(), "");
+            _uploadedBatches.Add(batch);
+            return new ApiResponse<object>(_statusCode, _headers, new object(), "");
         }
 
         async public Task<ApiResponse<object>> UploadBatchAsync(Batch batch)
         {
             await Task.Run(() => Thread.Sleep(5));
-            uploadedBatches.Add(batch);
-            return new ApiResponse<object>(HttpStatusCode.Accepted, new object(), "");
+            _uploadedBatches.Add(batch);
+            return new ApiResponse<object>(_statusCode, _headers, new object(), "");
         }
 
         public void LogEvent(BaseEvent baseEvent)

--- a/src/mParticle.Sdk.Test/mParticle.Sdk.Test.csproj
+++ b/src/mParticle.Sdk.Test/mParticle.Sdk.Test.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <AssemblyName>mParticle.Test</AssemblyName>
     <RootNamespace>mParticle.Test</RootNamespace>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 <PrivateAssets>all</PrivateAssets>
 </PackageReference>
     <ProjectReference Include="..\mParticle.Sdk\mParticle.Sdk.csproj" />

--- a/src/mParticle.Sdk/mParticle.Sdk.csproj
+++ b/src/mParticle.Sdk/mParticle.Sdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>mParticle</AssemblyName>
     <PackageId>mParticle.Sdk</PackageId>
     <OutputType>Library</OutputType>

--- a/src/mParticle.Sdk/mParticle.Sdk.csproj
+++ b/src/mParticle.Sdk/mParticle.Sdk.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
## Summary
Handle 429 status code rate limiting for the logEvent/UploadQueue code path. Note this is NOT the s2s batch upload code path (as seen in our other s2s SDKs).

This is basically the same logic as the s2s 429 handling in that it calculates a timestamp, but since we handle the uploading internally and don't return a response object to the user, it's simpler.

This PR also updates the Newtonsoft.Json library since it had a recent security issue, as well as updates the .NET SDKs to versions that are still supported, which allowed for some cleanup in the CI actions (no longer need to install .NET Core 2.1).

NOTE: THIS IS MEANT TO BE REBASE MERGED **NOT** SQUASHED AS EACH COMMIT SHOULD STAND ON IT'S OWN IN THE GIT HISTORY

## Testing Plan
Unit tests were added and local testing was performed.

## Master Issue
Closes https://go.mparticle.com/work/SQDSDKS-4229
