### PR TITLE
ci:Add semgrep to CI runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Test
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,9 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+
+  security-checks:
+    name: "Security Lint Checks"
+    uses: mparticle/mparticle-workflows/.github/workflows/security-checks.yml@main
+    with:
+      base_branch: "master"


### PR DESCRIPTION
## Summary
* Adds dotnet and other language-specific static analysis to pull request runs. Note that this PR doesn't get us at baseline with the results it reports back yet.

## Testing Plan
* Tested with `semgrep --config="auto" ${mp-dotnet-sdk-repo}` locally, letting the actual Github runner do a run as well
